### PR TITLE
Single end read support 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 data
-ht-pamda.docx

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,22 +1,30 @@
-name: publish docker image to GH repo
+name: Publish Docker image to GitHub Container Registry
 
-on: [push]
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger only on version tags like v1.0.0
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Check out repository with all history and tags
+      # ✅ Ensure full Git history and tags are available for setuptools_scm
+      - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0     # Ensures full git history and tags are available for setuptools-scm
+          fetch-depth: 0
 
+      # 🛠️ Set up QEMU for cross-platform builds
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        
+
+      # 🛠️ Set up Docker Buildx
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        
+
+      # 🚀 Cache Docker layers to speed up builds
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -24,23 +32,31 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-            
-      - name: Login to Github Container Registry
+
+      # 🔐 Authenticate with GitHub Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get short SHA
-        id: slug
-        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-  
+
+      # 🏷️ Extract version tag from Git reference
+      - name: Get tag name
+        id: get_tag
+        run: echo "VERSION_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      # 🐳 Build and push Docker image with dynamic versioning
       - name: Build and push tamipami image
         uses: docker/build-push-action@v6
+        env:
+          BUILDKIT_CONTEXT_KEEP_GIT_DIR: true  # Ensures .git is preserved for setuptools_scm
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/usda-ars-gbru/tamipami:sha-${{ env.SHORT_SHA }}
+          tags: |
+            ghcr.io/usda-ars-gbru/tamipami:${{ env.VERSION_TAG }}
+            ghcr.io/usda-ars-gbru/tamipami:latest
           build-args: |
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/data/readme.md
+++ b/data/readme.md
@@ -17,6 +17,12 @@ for i in $(seq 34761000 34761011); do
 done
 ```
 
+To use wget on, for example, SRR34761000:
+```
+wget -O SRR34761000.fastq.gz https://trace.ncbi.nlm.nih.gov/Traces/sra-reads-be/fastq\?acc\=SRR34761000
+```
+
+
 ## Metadata files
 
 - [`Model.organism.animal.1.0.xlsx`](metadata/Model.organism.animal.1.0.xlsx) the NCBI Biosample metadata file

--- a/tamipami/assets/config.yaml
+++ b/tamipami/assets/config.yaml
@@ -39,7 +39,6 @@ codes:
     {'C', 'T'}
 
 bbmerge:
-  - 'ecco=t'
   - 'mix=f'
   - 'usejni=t'
   - 'nn=t'

--- a/tests/fastq/test_merge_reads_stream.py
+++ b/tests/fastq/test_merge_reads_stream.py
@@ -18,7 +18,7 @@ def test_count_pam_stream_counts_sequences(mocker):
     pamlen = 3
     orientation = "5prime"
     # The PAM is 'AAA', then the spacer
-    seq = "AAAGATTACA"
+    seq = 'TGTAATCTTT'
     record = SeqRecord(Seq(seq), id="test", description="")
     mock_parse = mocker.patch("tamipami.fastq.SeqIO.parse", return_value=[record])
     fastq_stream = io.StringIO("irrelevant")

--- a/tests/fastq/test_pam_stream.py
+++ b/tests/fastq/test_pam_stream.py
@@ -12,11 +12,17 @@ def make_fastq(records):
 def test_count_pam_stream_5prime_correct_count():
     # Guide: GGG, PAM length: 2, orientation: 5prime
     # Sequence: XXPAMGGGYY, PAM is at positions 2:4, guide at 4:7
+    #records = [
+    #    ("r1", "AACCGGGTT", "IIIIIIIII"),  # PAM: CC, guide: GGG
+    #    ("r2", "TTCCGGGAA", "IIIIIIIII"),  # PAM: CC, guide: GGG
+    #    ("r3", "AACCGGGTT", "IIIIIIIII"),  # PAM: CC, guide: GGG
+    #    ("r4", "AAGGGTTCC", "IIIIIIIII"),  # PAM: AA, guide: GGG
+    #]
     records = [
-        ("r1", "AACCGGGTT", "IIIIIIIII"),  # PAM: CC, guide: GGG
-        ("r2", "TTCCGGGAA", "IIIIIIIII"),  # PAM: CC, guide: GGG
-        ("r3", "AACCGGGTT", "IIIIIIIII"),  # PAM: CC, guide: GGG
-        ("r4", "AAGGGTTCC", "IIIIIIIII"),  # PAM: AA, guide: GGG
+        ("r1", 'AACCCGGTT', "IIIIIIIII"),  # PAM: CC, guide: GGG
+        ("r2", 'TTCCCGGAA', "IIIIIIIII"),  # PAM: CC, guide: GGG
+        ("r3", 'AACCCGGTT', "IIIIIIIII"),  # PAM: CC, guide: GGG
+        ("r4", 'GGAACCCTT', "IIIIIIIII"),  # PAM: AA, guide: GGG
     ]
     fastq = io.StringIO(make_fastq(records))
     kmer_counts, tot_reads, guide_detections = count_pam_stream("GGG", 2, "5prime", fastq)
@@ -34,10 +40,10 @@ def test_count_pam_stream_3prime_correct_count():
     # Guide: GGG, PAM length: 2, orientation: 3prime
     # Sequence: XXGGGPAMYY, PAM is at positions 5:7, guide at 2:5
     records = [
-        ("r1", "AAGGGCCAA", "IIIIIIIII"),  # PAM: CC, guide: GGG
-        ("r2", "TTGGGTTAA", "IIIIIIIII"),  # PAM: TT, guide: GGG
-        ("r3", "AAGGGCCAA", "IIIIIIIII"),  # PAM: CC, guide: GGG
-        ("r4", "AAGGGGGAA", "IIIIIIIII"),  # PAM: GG, guide: GGG
+        ("r1", 'TTGGCCCTT', "IIIIIIIII"),  # PAM: CC, guide: GGG
+        ("r2", 'TTAACCCAA', "IIIIIIIII"),  # PAM: TT, guide: GGG
+        ("r3", 'TTGGCCCTT', "IIIIIIIII"),  # PAM: CC, guide: GGG
+        ("r4", 'TTCCCCCTT', "IIIIIIIII"),  # PAM: GG, guide: GGG
     ]
     fastq = io.StringIO(make_fastq(records))
     kmer_counts, tot_reads, guide_detections = count_pam_stream("GGG", 2, "3prime", fastq)


### PR DESCRIPTION
- Added support for single-ended sequencing in the CLI and web app.
- Fixed a bug where bbmerge was using `ecco=t` and returning forward and reverse, unmerged error-corrected reads, not error-corrected merged reads. This had a minimal impact on results.
-  Updates to Docker builds and version tagging 
- Documentation updates