### PR TITLE
Fix read_count_check so the low-target-fraction warning can fire

### DIFF
--- a/tamipami/app.py
+++ b/tamipami/app.py
@@ -391,9 +391,9 @@ def data_checks(length, sdcutoff):
 
 
 def read_count_check(run_summ, minfrac):
-    expfrac = run_summ["exp"]["targets"] / run_summ["exp"]["targets"]
-    contfrac = run_summ["cont"]["targets"] / run_summ["cont"]["targets"]
-    if (expfrac or contfrac) < minfrac:
+    expfrac = run_summ["exp"]["targets"] / run_summ["exp"]["tot"]
+    contfrac = run_summ["cont"]["targets"] / run_summ["cont"]["tot"]
+    if expfrac < minfrac or contfrac < minfrac:
         return st.warning(
             "Only {:.1%} of merged experimental reads and {:.1%} \
                         of merged control reads contained a target. Please verify your Library, Spacer and Orientation settings".format(
@@ -419,6 +419,7 @@ def main(args):
             return
         st.session_state["run_summ"] = run_summ
         st.session_state["pamexpobj"] = pamexpobj
+        read_count_check(run_summ, config["min_target_frac"])
         st.markdown("## Library information")
         spacer, orientation = parse_lib(args)
         if "library" in args:

--- a/tests/app/test_read_count_check.py
+++ b/tests/app/test_read_count_check.py
@@ -1,0 +1,41 @@
+import pytest
+
+from tamipami import app
+
+
+class TestReadCountCheck:
+    """Checks that read_count_check flags runs where too few reads hit a target.
+
+    read_count_check calls st.warning when the fraction of reads containing a
+    guide target drops below minfrac, so the tests patch app.st.warning and
+    look at whether it was called.
+    """
+
+    def test_low_target_fraction_fires_warning(self, mocker):
+        warn = mocker.patch.object(app.st, "warning")
+        run_summ = {
+            "exp": {"tot": 1000, "targets": 50},
+            "cont": {"tot": 1000, "targets": 40},
+        }
+        app.read_count_check(run_summ, minfrac=0.5)
+        warn.assert_called_once()
+
+    def test_bad_control_only_fires_warning(self, mocker):
+        # Experimental fraction is fine (0.9) but the control fraction is bad
+        # (0.05). Both sides must be checked, so the warning should still fire.
+        warn = mocker.patch.object(app.st, "warning")
+        run_summ = {
+            "exp": {"tot": 1000, "targets": 900},
+            "cont": {"tot": 1000, "targets": 50},
+        }
+        app.read_count_check(run_summ, minfrac=0.5)
+        warn.assert_called_once()
+
+    def test_healthy_run_is_quiet(self, mocker):
+        warn = mocker.patch.object(app.st, "warning")
+        run_summ = {
+            "exp": {"tot": 1000, "targets": 800},
+            "cont": {"tot": 1000, "targets": 750},
+        }
+        app.read_count_check(run_summ, minfrac=0.5)
+        warn.assert_not_called()


### PR DESCRIPTION
The low-target-fraction QC warning in read_count_check can't ever fire. Both expfrac and contfrac divide targets by itself instead of by the total read count, so they're always 1.0, and the `(expfrac or contfrac) < minfrac` check short-circuits to expfrac and never looks at the control fraction. So a run with the wrong Library, Spacer or Orientation (where almost no reads contain a target) gets no warning.

This divides by tot instead (both keys are already set by process via fastq.process) and splits the condition so each side is checked on its own. I also wired the function into main after process using the existing min_target_frac config value, since it was defined but never actually called.

Added a few tests: they fail on the current code (the warning stays silent) and pass after the change. The existing suite still passes (32 total).